### PR TITLE
Update devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Update the NODE_VERSION arg in docker-compose.yml to pick a Node version: 10, 12, 14
-ARG NODE_VERSION=14
+ARG NODE_VERSION=16
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${NODE_VERSION}
 
 # VARIANT can be either 'hugo' for the standard version or 'hugo_extended' for the extended version.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,30 +12,29 @@
 			// Rebuild the container if it already exists to update.
 			"VERSION": "0.78.1",
 			// Update NODE_VERSION to pick the Node.js version: 12, 14
-			"NODE_VERSION": "14",
+			"NODE_VERSION": "16",
 			"BUILDKIT_INLINE_CACHE": "0"
 		}
 	},
-
-	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"html.format.templating": true,
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"html.format.templating": true
+			}
+		},
+		// Set *default* container specific settings.json values on container create.
+		// Add the IDs of extensions you want installed when the container is created.
+		"extensions": [
+			"bungcip.better-toml",
+			"davidanson.vscode-markdownlint"
+		],
 	},
-	
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"bungcip.better-toml",
-		"davidanson.vscode-markdownlint"
-	],
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
 		1313
 	],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "uname -a",
-
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node"
 }


### PR DESCRIPTION
Docker build fails with node 14. Use 16 instead.
Update devcontainer.json. Root level `settings` and `extensions` properties are deprecated. Move to new structure (customizations->vscode)