### PR TITLE
Change URLs from eclipse.org to eclipse.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sources of the GLSP Website
 
-This page hosts the sources of [eclipse.org/glsp](https://www.eclipse.org/glsp).
+This page hosts the sources of [eclipse.dev/glsp](https://www.eclipse.dev/glsp).
 We use the [Syna](https://github.com/okkur/syna) thema for [Hugo](https://gohugo.io/)
 
 Please check the [Syna documentation](https://about.okkur.org/syna/docs/). The Syna theme heavily works with fragments, therefore the development differs a bit from a "normal" Hugo website.

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://www.eclipse.org/glsp"
+baseURL = "https://www.eclipse.dev/glsp"
 DefaultContentLanguage = "en"
 title = "Eclipse Graphical Language Server Platform"
 theme = "syna"
@@ -91,12 +91,12 @@ lastmod = ["lastmod", ":git", "date"]
   weight = 60
 
 [[menu.footer]]
-  url = "https://projects.eclipse.org/projects/ecd.sprotty"
+  url = "https://sprotty.org"
   name = "Eclipse Sprotty"
   weight = 10
 
 [[menu.footer]]
-  url = "https://www.eclipse.org/emfcloud"
+  url = "https://www.eclipse.dev/emfcloud"
   name = "Eclipse EMF.cloud"
   weight = 20
 
@@ -106,7 +106,7 @@ lastmod = ["lastmod", ":git", "date"]
   weight = 30
 
 [[menu.footer]]
-  url = "https://eclipse.org/che"
+  url = "https://eclipse.dev/che"
   name = "Eclipse Che"
   weight = 50
 

--- a/content/documentation/gettingStarted/content.md
+++ b/content/documentation/gettingStarted/content.md
@@ -14,7 +14,7 @@ GLSP is architected to be very flexible and provides several implementation opti
    GLSP servers can be written either in Java or with Typescript based on nodejs.
 * 🗂️ **Source Model**<br/>
    You can use any format or framework for managing your source model.
-   For the most common choices, GLSP provides dedicated base modules, such as for [EMF](https://www.eclipse.org/modeling/emf), [emf.cloud](https://www.eclipse.org/emfcloud), or GModel-JSON, which contains the graphical model directly.
+   For the most common choices, GLSP provides dedicated base modules, such as for [EMF](https://www.eclipse.dev/modeling/emf), [emf.cloud](https://www.eclipse.dev/emfcloud), or GModel-JSON, which contains the graphical model directly.
 * 🖼️ **Tool Platform**<br/>
    Diagram editors can used in multiple tool platforms or used in plain web applications or in an Electron app.
    While GLSP editors can be integrated into any web application, GLSP provides dedicated integration components for seamlessly deploying a GLSP editor inside of [Eclipse Theia](https://www.theia-ide.org), [VS Code](https://code.visualstudio.com), or [Eclipse RCP](https://www.eclipse.org/ide).

--- a/content/documentation/gmodel/content.md
+++ b/content/documentation/gmodel/content.md
@@ -46,7 +46,7 @@ Semantically, those elements, however, are equivalent and are exchanged transpar
 
 #### GModel: Graphical model on the server
 
-The [Java-based GLSP server](https://github.com/eclipse-glsp/glsp-server) uses [EMF](https://www.eclipse.org/modeling/emf) to represent and manage the graphical model internally.
+The [Java-based GLSP server](https://github.com/eclipse-glsp/glsp-server) uses [EMF](https://www.eclipse.dev/modeling/emf) to represent and manage the graphical model internally.
 Note that this is just an internal way of representing the `GModel` at runtime but doesn’t mean that adopters need to represent their original source models with EMF too.
 The GLSP server uses EMF in order to reuse its model management and editing capabilities, its command stack and command-based editing.
 Therefore, the graphical model is described as an Ecore model and the corresponding Java classes are automatically generated from this model.

--- a/content/documentation/integrations/content.md
+++ b/content/documentation/integrations/content.md
@@ -15,7 +15,7 @@ On this page, we give an overview of the dedicated integration components and po
    GLSP servers can be written either in Java or with Typescript based on nodejs.
 * 🗂️ [**Source Model**](#source-model-integrations)<br/>
    You can use any format or framework for managing your source model.
-   For the most common choices, GLSP provides dedicated base modules, such as for [EMF](https://www.eclipse.org/modeling/emf), [emf.cloud](https://www.eclipse.org/emfcloud), or GModel-JSON, which contains the graphical model directly.
+   For the most common choices, GLSP provides dedicated base modules, such as for [EMF](https://www.eclipse.dev/modeling/emf), [emf.cloud](https://www.eclipse.dev/emfcloud), or GModel-JSON, which contains the graphical model directly.
 * 🖼️ [**Tool Platform**](#platform-integrations)<br/>
    Diagram editors can used in multiple tool platforms or used in plain web applications or in an Electron app.
    GLSP provides dedicated integration components for seamlessly deploying a GLSP editor inside of [Eclipse Theia](https://www.theia-ide.org), [VS Code](https://code.visualstudio.com), or [Eclipse RCP](https://www.eclipse.org/ide).

--- a/content/documentation/sourceModel/content.md
+++ b/content/documentation/sourceModel/content.md
@@ -11,7 +11,7 @@ title = "Source Model & Model State"
 ### Source Model
 
 The source model represents the actual data that is represented in the diagram and that is modified when the user applies changes in the diagram.
-Typical source model formats are [EMF](https://www.eclipse.org/modeling/emf) models, JSON files, and databases, etc.
+Typical source model formats are [EMF](https://www.eclipse.dev/modeling/emf) models, JSON files, and databases, etc.
 However, GLSP and the GLSP server frameworks don't put any restrictions on what the format of this source model is.
 This is achieved by putting developers of GLSP diagram servers in charge of defining how to load a source model, how to transform it into a [graphical model]({{< ref "gmodel" >}}), which is the description of the diagram to be rendered, and how to manipulate the source model, if a user edits a diagram.
 

--- a/content/gallery/autolayout.md
+++ b/content/gallery/autolayout.md
@@ -15,4 +15,4 @@ title = "Auto Layout"
   image = "autolayout.gif"
 +++
 
-An example for auto layout in a diagram. See [here](https://www.eclipse.org/glsp/documentation/#workflowoverview) for more details.
+An example for auto layout in a diagram. See [here](https://www.eclipse.dev/glsp/documentation/#workflowoverview) for more details.

--- a/content/gallery/customcontextactions.md
+++ b/content/gallery/customcontextactions.md
@@ -14,4 +14,4 @@ title = "Custom Context Actions"
   image = "customcontextactions.gif"
 +++
 
-A custom context action in the workflow example. See [here](https://www.eclipse.org/glsp/documentation/#workflowoverview) for more details.
+A custom context action in the workflow example. See [here](https://www.eclipse.dev/glsp/documentation/#workflowoverview) for more details.

--- a/content/gallery/ecoreeditor.md
+++ b/content/gallery/ecoreeditor.md
@@ -15,4 +15,4 @@ title = "Ecore Editor"
   image = "ecoreeditor.gif"
 +++
 
-The Ecore Editor provided by [EMF.cloud](https://www.eclipse.org/emfcloud/). See [here](https://github.com/eclipse-emfcloud/ecore-glsp) for more details.
+The Ecore Editor provided by [EMF.cloud](https://www.eclipse.dev/emfcloud/). See [here](https://github.com/eclipse-emfcloud/ecore-glsp) for more details.

--- a/content/gallery/workflowexample.md
+++ b/content/gallery/workflowexample.md
@@ -15,4 +15,4 @@ title = "Workflow example"
   image = "diagramanimated.gif"
 +++
 
-An example workflow diagram available open source. See [here](https://www.eclipse.org/glsp/documentation/#workflowoverview) for more details.
+An example workflow diagram available open source. See [here](https://www.eclipse.dev/glsp/documentation/#workflowoverview) for more details.


### PR DESCRIPTION
More information on this migration can be found at https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3069